### PR TITLE
View.proptypes are deprecated in favor for ViewPropTypes for iOS too

### DIFF
--- a/src/RecyclerViewList.ios.js
+++ b/src/RecyclerViewList.ios.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
-import ReactNative, { View, requireNativeComponent, DeviceEventEmitter, StyleSheet, UIManager } from 'react-native';
+import ReactNative, { View, requireNativeComponent, DeviceEventEmitter, StyleSheet, UIManager, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import DataSource from './DataSource';
 
 class RecyclerViewItem extends Component {
   static propTypes = {
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     itemIndex: PropTypes.number,
     itemKey: PropTypes.number,
     shouldUpdate: PropTypes.bool,


### PR DESCRIPTION
Update the `RecyclerViewList.ios.js` variant to replace the use of the deprecated `View.propTypes` for `ViewPropTypes`.

The deprecation and replacement has already happened on the [non-variant module](https://github.com/wordpress-mobile/react-native-recyclerview-list/blob/master/src/RecyclerViewList.js#L8).