### PR TITLE
Upgrade react native

### DIFF
--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
@@ -160,7 +160,7 @@ public class RecyclerViewBackedScrollViewManager extends ViewGroupManager<Recycl
     @Override
     public @Nullable Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.builder()
-                .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
+                .put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"))
                 .put(ContentSizeChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onContentSizeChange"))
                 .put(VisibleItemsChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onVisibleItemsChange"))
                 .build();

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.3.0-alpha.1",
-    "react-native": "^0.54.2"
+    "react": "^16.6.3",
+    "react-native": "^0.57.5"
   },
   "dependencies": {
     "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.6.3",
-    "react-native": "^0.57.5"
+    "react": "16.6.1",
+    "react-native": "0.57.5"
   },
   "dependencies": {
     "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-recyclerview-list",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "description": "A RecyclerView implementation for React Native",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Upgrading react-native to 0.57.5 in `gutenberg-mobile` will require some changes in `react-native-recyclerview-list` as some internal react native classes have changed:
- `ScrollEventType` enum's method `getJSEventName` is now static