### PR TITLE
Make EditText selectable when view attached to window

### DIFF
--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollView.java
@@ -2,17 +2,18 @@ package com.github.godness84.RNRecyclerViewList;
 
 import android.content.Context;
 import android.graphics.PointF;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.LinearSmoothScroller;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.SystemClock;
@@ -158,6 +159,7 @@ public class RecyclerViewBackedScrollView extends RecyclerView {
         private final RecyclerViewBackedScrollView mScrollView;
         private int mItemCount = 0;
 
+
         public ReactListAdapter(RecyclerViewBackedScrollView scrollView) {
             mScrollView = scrollView;
             //setHasStableIds(true);
@@ -203,6 +205,42 @@ public class RecyclerViewBackedScrollView extends RecyclerView {
         public void onViewRecycled(ConcreteViewHolder holder) {
             super.onViewRecycled(holder);
             ((RecyclableWrapperViewGroup) holder.itemView).removeAllViews();
+        }
+
+        @Override
+        public void onViewAttachedToWindow(@NonNull ConcreteViewHolder holder) {
+            ArrayList<View> allEditTextsInViewGroup = getAllEditTextChildren(holder.itemView);
+            for (View child : allEditTextsInViewGroup) {
+                EditText editText = (EditText) child;
+                // by default, an EditText that is focusable should also be selectable, so
+                // we should be safe to make sure text is selectable by resetting it.
+                if (editText.isFocusable()) {
+                    editText.setTextIsSelectable(true);
+                }
+            }
+
+            super.onViewAttachedToWindow(holder);
+        }
+
+        private ArrayList<View> getAllEditTextChildren(View v) {
+            if (!(v instanceof ViewGroup)) {
+                ArrayList<View> viewArrayList = new ArrayList<View>();
+                if (v instanceof EditText) {
+                    viewArrayList.add(v);
+                }
+                return viewArrayList;
+            }
+
+            ArrayList<View> result = new ArrayList<View>();
+
+            ViewGroup vg = (ViewGroup) v;
+            for (int i = 0; i < vg.getChildCount(); i++) {
+                View child = vg.getChildAt(i);
+                ArrayList<View> childChildren = new ArrayList<View>();
+                childChildren.addAll(getAllEditTextChildren(child));
+                result.addAll(childChildren);
+            }
+            return result;
         }
 
         @Override

--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
@@ -160,7 +160,7 @@ public class RecyclerViewBackedScrollViewManager extends ViewGroupManager<Recycl
     @Override
     public @Nullable Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.builder()
-                .put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"))
+                .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
                 .put(ContentSizeChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onContentSizeChange"))
                 .put(VisibleItemsChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onVisibleItemsChange"))
                 .build();

--- a/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
+++ b/android/src/main/java/com/github/godness84/RNRecyclerViewList/RecyclerViewBackedScrollViewManager.java
@@ -160,7 +160,7 @@ public class RecyclerViewBackedScrollViewManager extends ViewGroupManager<Recycl
     @Override
     public @Nullable Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.builder()
-                .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
+                .put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"))
                 .put(ContentSizeChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onContentSizeChange"))
                 .put(VisibleItemsChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onVisibleItemsChange"))
                 .build();

--- a/example/App.js
+++ b/example/App.js
@@ -209,8 +209,9 @@ class Item extends Component {
     return (
       <TouchableHighlight
         onPress={onIncrementCounter}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', marginHorizontal: 5 }}>
-          <TextInput/>
+        {/* <View style={{ flexDirection: 'row', alignItems: 'center', marginHorizontal: 5 }}> */}
+        <View>
+          <TextInput value="hello"/>
           <Image
             source={{ uri: 'http://loremflickr.com/320/240?t=' + (id % 9) }}
             style={{

--- a/example/App.js
+++ b/example/App.js
@@ -15,7 +15,8 @@ import {
   Button,
   TouchableHighlight,
   ToastAndroid,
-  SafeAreaView
+  SafeAreaView,
+  TextInput,
 } from 'react-native';
 
 import RecyclerViewList, { DataSource } from 'react-native-recyclerview-list';
@@ -209,6 +210,7 @@ class Item extends Component {
       <TouchableHighlight
         onPress={onIncrementCounter}>
         <View style={{ flexDirection: 'row', alignItems: 'center', marginHorizontal: 5 }}>
+          <TextInput/>
           <Image
             source={{ uri: 'http://loremflickr.com/320/240?t=' + (id % 9) }}
             style={{


### PR DESCRIPTION
It's been detected that RN's `TextInput` components within the list, that are shown offscreen when the list is first loaded, do not allow their text to be selected.

#### Background
On the technical side, apparently the problem with RN’s `TextInput` should be fixed in this commit https://github.com/facebook/react-native/commit/89340f1620295c7ca6baecccc6b6d3befdf45cdb but we can see it still happens, and for some reason while this code exists for TextView, this modification is not on EditText anymore (see current RN master https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java)
(EDIT: the code has been reverted super shortly after in https://github.com/facebook/react-native/commit/862136a398decff8ad5d4509ca51bd6b893ff851#diff-457fd2ba359cc6fbb0c471516e279696, with the apparent intention to get it back in but never did).

As a workaround, this PR makes sure any EditText that's within a list row view hierarchy gets set to selectable if focusable when it gets attached to the window (that is, when it's about to become visible and hence actionable).

To test:
Before:
1. run the app
2. observe the word `hello` in the `TextInput`  is selectable in the first few rows being shown
4. scroll the list down (1 screen down is enough, as the problem happens with items that are not visible on first load)
5. now place the cursor on the TextInput of any of these items and try selecting text. Observe it's not possible.

![recyclerv_offscreen_items_not_ok](https://user-images.githubusercontent.com/6597771/48848657-42157000-ed83-11e8-944d-45c9d3841ff8.gif)


After:
Repeat the steps above and observe all `TextInput` is selectable.
![recyclerv_offscreen_items_yes_ok](https://user-images.githubusercontent.com/6597771/48848707-64a78900-ed83-11e8-8cc3-664788ab8ef8.gif)

 