### PR TITLE
Ability to build a binary via jitpack

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ android {
 repositories {
     google()
     jcenter()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "https://unpkg.com/react-native@0.57.5/android"
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,9 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+// import the `readReactNativeVersion()` function
+apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
+
 android {
     compileSdkVersion 27
     buildToolsVersion "27.0.3"
@@ -30,9 +33,16 @@ android {
 repositories {
     google()
     jcenter()
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "https://unpkg.com/react-native@0.57.5/android"
+
+    if (project == rootProject) {
+        // if we are the root project, use a remote RN maven repo so jitpack can build this lib without local RN setup
+        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        def unpkgUrl = "https://unpkg.com/react-native@${rnVersion}/android"
+        println "Will use the unpkg.com exposed RN maven repo at ${unpkgUrl}"
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url unpkgUrl
+        }
     }
 }
 


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/react-native-aztec/pull/80, this PR enabled building the library as a standalone project.

### To test

0. Make sure there is no `node_modules` folder, either in the root or in the `example` folder
1. `cd` into the `android` subfolder and build by issuing `./gradlew assemble`
2. The build should succeed
3. Scroll up and notice the `Will use the unpkg.com exposed RN maven repo at https://unpkg.com/react-native@0.57.5/android` printout which shows that the remote maven repo was in effect.