### PR TITLE
updated sdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.android.library'
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -94,8 +94,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.example"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -95,7 +95,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.example"


### PR DESCRIPTION
Title has it - needed to do this when trying to compile Mobile Gutenberg from scratch due to this exception:

```
> Task :WordPress:mergeVanillaDebugResources

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-recyclerview-list:verifyReleaseResources'.
> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
  Output:  /Users/mariozorz/proyectos/WordPress-Android/libs/gutenberg-mobile/node_modules/react-native-recyclerview-list/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:7: error: resource android:attr/dialogCornerRadius not found.
  /Users/mariozorz/proyectos/WordPress-Android/libs/gutenberg-mobile/node_modules/react-native-recyclerview-list/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:11: error: resource android:attr/dialogCornerRadius not found.
  /Users/mariozorz/proyectos/WordPress-Android/libs/gutenberg-mobile/node_modules/react-native-recyclerview-list/android/build/intermediates/res/merged/release/values/values.xml:957: error: resource android:attr/fontVariationSettings not found.
  /Users/mariozorz/proyectos/WordPress-Android/libs/gutenberg-mobile/node_modules/react-native-recyclerview-list/android/build/intermediates/res/merged/release/values/values.xml:958: error: resource android:attr/ttcIndex not found.
  error: failed linking references.
  
  Command: /Users/mariozorz/.gradle/caches/transforms-1/files-1.1/aapt2-3.2.1-4818971-osx.jar/a001ec0b949b02acd48d2a5ed98b9ca2/aapt2-3.2.1-4818971-osx/aapt2 link -I\
          /Users/mariozorz/Library/Android/sdk/platforms/android-27/android.jar\
          --manifest\
```

The `sdkVersion` was updated on the main project but not on this one and, for some reason it continued to work alright until a build from scratch was attempted. This seems to fix it.

Next steps:
- [x] once/if this one gets merged, create a new release `1.0.1` on this repo
- [x] ~update reference in `gutenberg-mobile` repo here https://github.com/wordpress-mobile/gutenberg-mobile/blob/19a4c13d053dd7e076c0607e18658eff40d590fd/package.json#L117~ PR up here https://github.com/wordpress-mobile/gutenberg-mobile/pull/796
- [x] check it builds ok for both gutenberg demo app and WPAndroid app

