### PR TITLE
Fix compatibility with RN 0.60.0

### DIFF
--- a/ios/RNReactNativeRecyclerviewList.podspec
+++ b/ios/RNReactNativeRecyclerviewList.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
   #s.dependency "others"
 
 end


### PR DESCRIPTION
This makes a change to be compatible with RN 0.60.0:

- Depend only on `React-Core` instead of all of React.